### PR TITLE
Change Type of the trackMetric params

### DIFF
--- a/src/@ionic-native-mocks/plugins/google-analytics/index.ts
+++ b/src/@ionic-native-mocks/plugins/google-analytics/index.ts
@@ -79,7 +79,7 @@ export class GoogleAnalyticsMock extends GoogleAnalytics {
      * @param value {any}
      * @returns {Promise<any>}
      */
-    trackMetric(key: number, value?: number): Promise<any> {
+    trackMetric(key: string, value?: any): Promise<any> {
          return new Promise((resolve, reject) => {
             resolve();
         });


### PR DESCRIPTION
The type of the trackMetric params doesn't match with ga plugin