### PR TITLE
Globalization setDefaultLanguage static function

### DIFF
--- a/src/@ionic-native-mocks/plugins/globalization/index.ts
+++ b/src/@ionic-native-mocks/plugins/globalization/index.ts
@@ -1,12 +1,27 @@
 import { Globalization } from '@ionic-native/globalization';
 
 export class GlobalizationMock extends Globalization {
+
+    private _defaultLanguage: string = 'en-EN';
+
     /**
-        * Returns the BCP-47 compliant language identifier tag to the successCallback with a properties object as a parameter. That object should have a value property with a String value.
-        * @returns {Promise<{value: string}>}
-        */
+    * Starts globalization plugin mock with a default language if it is necessary, otherwise default language is English.
+    * If defaulLanguage property is used, please, You should use this format to inject provider:
+    * { provide: Globalization, useFactory: () => new GlobalizationMock('es-ES') },
+    * 
+    */
+    constructor(defaultLanguage?: string) {
+        super();
+        this._defaultLanguage = defaultLanguage || this._defaultLanguage;
+    }
+    /**
+    * Returns the BCP-47 compliant language identifier tag to the successCallback with a properties object as a parameter. That object should have a value property with a String value.
+    * @returns {Promise<{value: string}>}
+    */
     getPreferredLanguage(): Promise<{ value: string; }> {
-        let theResult = { value: '' };
+        let theResult = {
+            value: this._defaultLanguage
+        };
         return new Promise((resolve, reject) => {
             resolve(theResult);
         });
@@ -16,7 +31,9 @@ export class GlobalizationMock extends Globalization {
      * @returns {Promise<{value: string}>}
      */
     getLocaleName(): Promise<{ value: string; }> {
-        let theResult = { value: '' };
+        let theResult = {
+            value: this._defaultLanguage
+        };
         return new Promise((resolve, reject) => {
             resolve(theResult);
         });

--- a/src/@ionic-native-mocks/plugins/globalization/index.ts
+++ b/src/@ionic-native-mocks/plugins/globalization/index.ts
@@ -2,16 +2,19 @@ import { Globalization } from '@ionic-native/globalization';
 
 export class GlobalizationMock extends Globalization {
 
-    private _defaultLanguage: string = 'en-EN';
+    private static _defaultLanguage: string = 'en-EN';
 
     /**
-    * Starts globalization plugin mock with a default language if it is necessary, otherwise default language is English.
-    * If defaulLanguage property is used, please, You should use this format to inject provider:
-    * { provide: Globalization, useFactory: () => new GlobalizationMock('es-ES') },
-    * 
+    * Set default language on globalization plugin mock, otherwise default language is English.
+    * You should use this format to inject provider:
+    *
+    * GlobalizationMock.setDefaultLanguage('es-ES');
+    *
+    * ... providers :[
+    *      { provide: Globalization, useClass: GlobalizationMock },
+    * ]
     */
-    constructor(defaultLanguage?: string) {
-        super();
+    static setDefaultLanguage(defaultLanguage: string) {
         this._defaultLanguage = defaultLanguage || this._defaultLanguage;
     }
     /**
@@ -20,7 +23,7 @@ export class GlobalizationMock extends Globalization {
     */
     getPreferredLanguage(): Promise<{ value: string; }> {
         let theResult = {
-            value: this._defaultLanguage
+            value: GlobalizationMock._defaultLanguage
         };
         return new Promise((resolve, reject) => {
             resolve(theResult);
@@ -32,7 +35,7 @@ export class GlobalizationMock extends Globalization {
      */
     getLocaleName(): Promise<{ value: string; }> {
         let theResult = {
-            value: this._defaultLanguage
+            value: GlobalizationMock._defaultLanguage
         };
         return new Promise((resolve, reject) => {
             resolve(theResult);


### PR DESCRIPTION
Constructor with optional property not injected properly on providers if you use useClass property. Removed constructor with optional property and updated with static function to set default value before inject providers.