### PR TITLE
bugfix/intel-security

### DIFF
--- a/src/@ionic-native-mocks/plugins/intel-security/index.ts
+++ b/src/@ionic-native-mocks/plugins/intel-security/index.ts
@@ -30,12 +30,12 @@ export  class IntelSecurityMock extends IntelSecurity {
      * returns an IntelSecurityStorage object
      * @type {IntelSecurityStorage}
      */
-    storage: IntelSecurityStorageMock;
+    storage: IntelSecurityStorageMock = new IntelSecurityStorageMock();
     /**
      * Returns an IntelSecurityData object
      * @type {IntelSecurityData}
      */
-    data: IntelSecurityDataMock;
+    data: IntelSecurityDataMock = new IntelSecurityDataMock();
 }
 /**
  * @hidden


### PR DESCRIPTION
Assign `IntelSecurityMock` properties to their mock classes by initializing the properties to the mock types.