### PR TITLE
update http mock - fix error "Class HTTPMock incorrectly extends base class HTTP" on run "ionic serve"

### DIFF
--- a/src/@ionic-native-mocks/plugins/http/index.ts
+++ b/src/@ionic-native-mocks/plugins/http/index.ts
@@ -6,13 +6,17 @@ export interface HTTPResponse {
      */
     status: number;
     /**
-     * The data that is in the response. This property usually exists when a promise returned by a request method resolves.
-     */
-    data?: any;
-    /**
      * The headers of the response
      */
     headers: any;
+    /**
+     * The URL of the response. This property will be the final URL obtained after any redirects.
+     */
+    url: string;
+    /**
+     * The data that is in the response. This property usually exists when a promise returned by a request method resolves.
+     */
+    data?: any;
     /**
      * Error response from the server. This property usually exists when a promise returned by a request method rejects.
      */


### PR DESCRIPTION
It seems, that interface HTTPResponse got enhancements, so when running "ionic serve" there was compile error "Class HTTPMock incorrectly extends base class HTTP"